### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 ; vi:syntax=ini
-; See https://coverage.readthedocs.org/en/coverage-4.0.3/config.html
+; See https://coverage.readthedocs.io/en/coverage-4.0.3/config.html
 
 [run]
 data_file = .coverage

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ python_hangman
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/python-hangman/badge/?version=develop
-    :target: https://python-hangman.readthedocs.org/en/develop/?badge=develop
+    :target: https://python-hangman.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 
@@ -60,7 +60,7 @@ Features
 ========
 
 - Hangman!
-- Documentation: https://python_hangman.readthedocs.org
+- Documentation: https://python_hangman.readthedocs.io
 - Open Source: https://github.com/bionikspoon/python_hangman
 - Idiomatic code.
 - Thoroughly tested with very high coverage.

--- a/docs/source/readme_features.rst
+++ b/docs/source/readme_features.rst
@@ -2,7 +2,7 @@ Features
 ========
 
 - Hangman!
-- Documentation: https://python_hangman.readthedocs.org
+- Documentation: https://python_hangman.readthedocs.io
 - Open Source: https://github.com/bionikspoon/python_hangman
 - Idiomatic code.
 - Thoroughly tested with very high coverage.

--- a/docs/source/readme_title.rst
+++ b/docs/source/readme_title.rst
@@ -19,7 +19,7 @@ python_hangman
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/python-hangman/badge/?version=develop
-    :target: https://python-hangman.readthedocs.org/en/develop/?badge=develop
+    :target: https://python-hangman.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
 """
-The full documentation is at https://python_hangman.readthedocs.org.
+The full documentation is at https://python_hangman.readthedocs.io.
 """
 
 try:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
